### PR TITLE
Fix translation details and add BitDevs locations

### DIFF
--- a/01-introduction/04-bitdevs-en-espanol.md
+++ b/01-introduction/04-bitdevs-en-espanol.md
@@ -12,6 +12,11 @@ Ubicaciones reconocidas de BitDevs en español:
 
 ### América Latina
 - [BitDevs Buenos Aires](https://bitdevsba.org/) – Argentina
+- [BitDevs Córdoba](https://bitdevscordoba.org/) – Argentina
+- [BitDevs Santiago](https://santiagobitdevs.com/) – Chile
+
+### Online
+- [BitDevs Latino](https://www.bitdevs.lat/) – Comunidad hispanohablante general
 
 Esta red continúa creciendo a medida que más ciudades en el mundo hispanohablante dan el paso adelante para construir, aprender y liderar dentro de la comunidad global de Bitcoin.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Contacto](https://img.shields.io/badge/contacto-builders@btrust.tech-deepgreen?style=flat-square)](mailto:builders@btrust.tech)
 [![Licencia: CC BY 4.0](https://img.shields.io/badge/Licencia-CC%20BY%204.0-blue?style=flat-square)](LICENSE.md)
 
+> **Nota**: Este repositorio es una versión traducida y adaptada al español del [The BitDevs Playbook](https://github.com/btrustteam/the-bitdevs-playbook) original de Btrust. Todos los créditos del contenido original corresponden a sus autores y contribuidores.
+>
 > **Estado:** Versión en español (v0.1.0-es) - Febrero 2026. Basada en la versión original activamente en uso por las ubicaciones de BitDevs apoyadas por Btrust en África.
 >
 > **Nota**: A medida que las ubicaciones de BitDevs crecen, mejoran y comparten nuevas lecciones, este manual evolucionará para reflejar estos conocimientos y fortalecer el ecosistema.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ El manual refleja el ciclo de vida de una ubicación de BitDevs: configuración,
 | Andrea Diaz Correia | Traductora           | Organizadora Principal, BitDevs Buenos Aires | [@AndreaDiazCorreia](https://github.com/AndreaDiazCorreia)
 
 **Patrocinadores de la versión en español:**
-- [Librería de Satoshi](https://libreriasatoshi.com/)
+- [Librería de Satoshi](https://libreriadesatoshi.com/)
 - [b4os](https://b4os.dev/)
 
 Sponsors de BitDevs en Latinoamérica, apoyando el crecimiento de comunidades técnicas de Bitcoin en la región hispanohablante.


### PR DESCRIPTION
Add attribution note in README linking to the original Btrust repository, fix Librería de Satoshi URL typo, and add new BitDevs locations (BitDevs Córdoba, BitDevs Santiago, BitDevs Latino) to the Spanish-speaking locations list.